### PR TITLE
Mellow UI 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@hooks/*": ["./src/hooks/*"]
     }
   },
-  "include": ["src/components"],
+  "include": ["src/components", "src/hooks"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Mellow UI 0.8.1 fixes missing TypeScript definitions for the new `useColor` hook.

## Fixes
- f2aa254 Fixes missing type declarations for the included hooks.