### PR TITLE
Mellow UI 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -39,6 +39,10 @@ export interface InputControlProps {
    */
   inputProps?: InputProps;
   /**
+   * Make the field required
+   */
+  required?: boolean;
+  /**
    * Custom classes for the label
    */
   className?: string;
@@ -61,6 +65,7 @@ export const InputControl = ({
   inputProps,
   labelProps,
   placeholder,
+  required,
   helper,
   onChange,
   ...props
@@ -77,6 +82,7 @@ export const InputControl = ({
         placeholder={placeholder}
         onChange={onChange}
         aria-describedby={helper ? `${uniqueName}-help` : undefined}
+        required={required}
         {...inputProps}
         {...props}
       />


### PR DESCRIPTION
Mellow UI 0.9.1 is a minor bugfix release.

## Fixed issues
- ad89cfd Fixes a bug where an `InputControl` field could not be set as required.