### PR TITLE
Mellow UI 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -21,7 +21,7 @@ export interface InputControlProps {
   /**
    * The helper text
    */
-  helper: string;
+  helper?: string;
   /**
    * Placeholder of the input
    */

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -1,7 +1,8 @@
-import { ChangeEventHandler } from 'react';
-import { InputLabel, InputLabelProps, Input, InputProps } from '..';
+import clsx from 'clsx';
+import { InputHTMLAttributes } from 'react';
+import { InputLabel } from '..';
 
-export interface InputControlProps {
+export interface InputControlProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * ID of the input
    */
@@ -27,29 +28,13 @@ export interface InputControlProps {
    */
   placeholder?: string;
   /**
-   * Props for the label
+   * Type of the input
    */
-  labelProps?: InputLabelProps;
-  /**
-   * Props for the label
-   */
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Props for the input
-   */
-  inputProps?: InputProps;
-  /**
-   * Make the field required
-   */
-  required?: boolean;
+  type?: string;
   /**
    * Custom classes for the label
    */
   className?: string;
-  /**
-   * Type of the input
-   */
-  type?: string;
 }
 
 /**
@@ -62,31 +47,28 @@ export const InputControl = ({
   className,
   value,
   type,
-  inputProps,
-  labelProps,
   placeholder,
-  required,
   helper,
-  onChange,
   ...props
 }: InputControlProps) => {
   const uniqueName = name ?? id;
 
   return (
     <div className="form-floating">
-      <Input
+      <input
         name={uniqueName}
         id={id}
         type={type}
         value={value}
+        className={clsx(
+          'input',
+          className
+        )}
         placeholder={placeholder}
-        onChange={onChange}
         aria-describedby={helper ? `${uniqueName}-help` : undefined}
-        required={required}
-        {...inputProps}
         {...props}
       />
-      <InputLabel id={name} {...labelProps}>{label}</InputLabel>
+      <InputLabel id={uniqueName}>{label}</InputLabel>
       {helper && <div id={`${uniqueName}-help`} className="input-text">{helper}</div>}
     </div>
   );

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -1,6 +1,6 @@
-import React, { FormEventHandler, ReactNode, Fragment, useMemo } from 'react';
+import React, { ReactNode, Fragment, useMemo } from 'react';
 
-import { InputLabel, InputLabelProps } from '..';
+import { InputLabel } from '..';
 
 import { Listbox, Transition } from '@headlessui/react';
 
@@ -58,10 +58,6 @@ export interface SelectControlProps {
    */
   floating?: boolean;
   /**
-   * Props for the label
-   */
-  labelProps?: InputLabelProps;
-  /**
    * Custom classes for the label
    */
   className?: string;
@@ -86,7 +82,6 @@ export const SelectControl = ({
   getValue = (x) => x.value,
   disabled,
   floating = false,
-  labelProps,
   label,
   helper,
   ...props
@@ -121,7 +116,7 @@ export const SelectControl = ({
           </Listbox.Options>
         </Transition>
       </Listbox>
-      <InputLabel id={name} shrink={!!value} {...labelProps}>{label}</InputLabel>
+      <InputLabel id={uniqueName} shrink={!!value}>{label}</InputLabel>
       {helper && <div id={`${uniqueName}-help`} className="input-text">{helper}</div>}
     </div>
   );

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -24,7 +24,7 @@ export interface SelectControlProps {
   /**
    * The helper text
    */
-  helper: string;
+  helper?: string;
   /**
    * The placeholder for the select
    */


### PR DESCRIPTION
Mellow UI 0.9.2 includes an rewritten `InputControl` and various minor bugfixes.

## Changes
- [x] 49ada91 Rewrite `InputControl` to use the native `input` element directly.
  - `InputControl` no longer accepts `InputLabel` and `Input` as parameters.
  - `SelectControl` no longer accepts `InputLabel` as a parameter.

## Fixes
- [x] 025ff68 Fixes an issue where `InputControl` and `SelectControl` required `helper` to be set.