### PR TITLE
Mellow UI 0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "react-router-dom": "^6.3.0",
         "refractor": "^4.7.0",
         "typescript": "4.7.4",
-        "vite": "2.9.12",
+        "vite": "2.9.13",
         "vite-plugin-dts": "1.2.0"
       },
       "peerDependencies": {
-        "@sippy-platform/mellow-css": "^0.8.0",
+        "@sippy-platform/mellow-css": "^0.9.0",
         "@sippy-platform/valkyrie": ">=0.15.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@sippy-platform/mellow-css": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.8.0.tgz",
-      "integrity": "sha512-XAfAfS/YtGupP9dGSprdYlrSvm839Ucqxawdd/tWOcmkMg+6GmDwjZYfrNF7K9JScx2QCIPwxqN427ea8QPYKQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.9.0.tgz",
+      "integrity": "sha512-e+i6rFH8EpkZOKrd5mleR/Ng61zLh/ZrZ2ptu9wuW3dxfnMMdSVzNxQcGCq6y0g2FZimn5YmyS8GcgwvpUAgIQ==",
       "peer": true,
       "peerDependencies": {
         "@sippy-platform/valkyrie": ">=0.15.0"
@@ -1231,6 +1231,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2093,9 +2106,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.12",
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
+      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
@@ -2708,9 +2722,9 @@
       }
     },
     "@sippy-platform/mellow-css": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.8.0.tgz",
-      "integrity": "sha512-XAfAfS/YtGupP9dGSprdYlrSvm839Ucqxawdd/tWOcmkMg+6GmDwjZYfrNF7K9JScx2QCIPwxqN427ea8QPYKQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.9.0.tgz",
+      "integrity": "sha512-e+i6rFH8EpkZOKrd5mleR/Ng61zLh/ZrZ2ptu9wuW3dxfnMMdSVzNxQcGCq6y0g2FZimn5YmyS8GcgwvpUAgIQ==",
       "peer": true,
       "requires": {}
     },
@@ -3037,6 +3051,12 @@
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3523,7 +3543,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.12",
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
+      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
     "react-router-dom": "^6.3.0",
     "refractor": "^4.7.0",
     "typescript": "4.7.4",
-    "vite": "2.9.12",
+    "vite": "2.9.13",
     "vite-plugin-dts": "1.2.0"
   },
   "peerDependencies": {
-    "@sippy-platform/mellow-css": "^0.8.0",
+    "@sippy-platform/mellow-css": "^0.9.0",
     "@sippy-platform/valkyrie": ">=0.15.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/src/components/BottomBarItem/BottomBarItem.tsx
+++ b/src/components/BottomBarItem/BottomBarItem.tsx
@@ -22,7 +22,7 @@ export interface BottomBarItemProps extends ButtonHTMLAttributes<HTMLButtonEleme
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
   /**
    * Bottom bar item contents.
    */

--- a/src/components/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/BreadcrumbItem/BreadcrumbItem.tsx
@@ -22,7 +22,7 @@ export interface BreadcrumbItemProps extends ButtonHTMLAttributes<HTMLButtonElem
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
   /**
    * Bottom bar item contents.
    */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -38,7 +38,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
   /**
    * Button contents.
    */

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -14,7 +14,7 @@ export interface CardProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
   /**
    * Card contents.
    */

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -58,7 +58,7 @@ export interface ListItemProps {
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
 }
 
 /**

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -20,7 +20,7 @@ export interface MenuItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * As what the component should be rendered
    */
-  as?: string | ElementType;
+  as?: ElementType;
   /**
    * Custom classes for active items
    */

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode } from 'react';
+
+import { Tab } from '@headlessui/react';
+import clsx from 'clsx';
+
+export interface NavProps {
+  /**
+   * Custom classes for the label
+   */
+  className?: string;
+  /**
+   * The label attached to the label
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Primary UI component for user interaction
+ */
+export const Nav = ({
+  className,
+  children
+}: NavProps) => {
+  return (
+    <nav
+      className={
+        clsx(
+          'pivot',
+          className
+        )
+      }
+    >
+      {children}
+    </nav>
+  );
+};
+
+export default Nav;

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,6 +1,5 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
-import { Tab } from '@headlessui/react';
 import clsx from 'clsx';
 
 export interface NavProps {

--- a/src/components/Nav/index.ts
+++ b/src/components/Nav/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Nav';
+export type { NavProps } from './Nav';

--- a/src/components/NavItem/NavItem.tsx
+++ b/src/components/NavItem/NavItem.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+export interface NavItemProps {
+  /**
+   * Custom classes for the label
+   */
+  active?: boolean;
+  /**
+   * Custom classes for the label
+   */
+  className?: string;
+  /**
+   * The label attached to the label
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Primary UI component for user interaction
+ */
+export const NavItem = ({
+  className,
+  active,
+  children
+}: NavItemProps) => {
+  return (
+    <>
+      <button
+        className={clsx(
+          'pivot-link',
+          {
+            'active': active
+          },
+          className
+        )}
+      >
+        {children}
+      </button>
+    </>
+  );
+};
+
+export default NavItem;

--- a/src/components/NavItem/NavItem.tsx
+++ b/src/components/NavItem/NavItem.tsx
@@ -1,10 +1,14 @@
-import React, { ReactNode } from 'react';
+import { ElementType, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
 export interface NavItemProps {
   /**
-   * Custom classes for the label
+   * The type of the element
+   */
+  as?: ElementType;
+  /**
+   * Whether the element is active
    */
   active?: boolean;
   /**
@@ -21,24 +25,27 @@ export interface NavItemProps {
  * Primary UI component for user interaction
  */
 export const NavItem = ({
+  as = 'button',
   className,
   active,
-  children
+  children,
+  ...props
 }: NavItemProps) => {
+  const Component = as;
+
   return (
-    <>
-      <button
-        className={clsx(
-          'pivot-link',
-          {
-            'active': active
-          },
-          className
-        )}
-      >
-        {children}
-      </button>
-    </>
+    <Component
+      className={clsx(
+        'pivot-link',
+        {
+          'active': active
+        },
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
   );
 };
 

--- a/src/components/NavItem/index.ts
+++ b/src/components/NavItem/index.ts
@@ -1,0 +1,2 @@
+export { default } from './NavItem';
+export type { NavItemProps } from './NavItem';

--- a/src/components/PivotNav/PivotNav.tsx
+++ b/src/components/PivotNav/PivotNav.tsx
@@ -5,10 +5,6 @@ import clsx from 'clsx';
 
 export interface PivotNavProps {
   /**
-   * The array of options
-   */
-  variant?: 'default' | 'underline' | 'pills';
-  /**
    * Custom classes for the label
    */
   className?: string;
@@ -23,7 +19,6 @@ export interface PivotNavProps {
  */
 export const PivotNav = ({
   className,
-  variant = 'default',
   children
 }: PivotNavProps) => {
   return (
@@ -31,9 +26,6 @@ export const PivotNav = ({
       className={
         clsx(
           'pivot',
-          {
-            [`pivot-${variant}`]: variant !== 'default'
-          },
           className
         )
       }

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -95,7 +95,7 @@ export const SelectControl = ({
     <div className="form-floating">
       <Listbox value={value} onChange={onChange} disabled={disabled} name={uniqueName}>
         <Listbox.Button className={clsx('input-select', className)} {...props}>
-          <span className="text-truncate pt-3 pb-1">{currentValue ? getLabel(currentValue) : <span className="select-placeholder">{placeholder}</span>}</span>
+          <span className="text-truncate pt-4 pb-1">{currentValue ? getLabel(currentValue) : <span className="select-placeholder">{placeholder}</span>}</span>
           <span className="d-flex align-items-center">
             <ValkyrieIcon icon={viAngleDown} />
           </span>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -100,6 +100,12 @@ export type { MenuItemsProps } from '@components/MenuItems';
 export { default as MenuTrigger } from '@components/MenuTrigger';
 export type { MenuTriggerProps } from '@components/MenuTrigger';
 
+export { default as Nav } from '@components/Nav';
+export type { NavProps } from '@components/Nav';
+
+export { default as NavItem } from '@components/NavItem';
+export type { NavItemProps } from '@components/NavItem';
+
 export { default as Offcanvas } from '@components/Offcanvas';
 export type { OffcanvasProps } from '@components/Offcanvas';
 

--- a/src/docs/App.tsx
+++ b/src/docs/App.tsx
@@ -22,6 +22,7 @@ import LabelDemo from './pages/Components/LabelDemo';
 import Layout from './components/Layout';
 import ListDemo from './pages/Components/ListDemo';
 import MenuDemo from './pages/Components/MenuDemo';
+import NavDemo from './pages/Components/NavDemo';
 import OffcanvasDemo from './pages/Components/OffcanvasDemo';
 import PivotDemo from './pages/Components/PivotDemo';
 import ProgressDemo from './pages/Components/ProgressDemo';
@@ -50,6 +51,7 @@ function App() {
         <Route path="/label" element={<LabelDemo />} />
         <Route path="/list" element={<ListDemo />} />
         <Route path="/menu" element={<MenuDemo />} />
+        <Route path="/nav" element={<NavDemo />} />
         <Route path="/offcanvas" element={<OffcanvasDemo />} />
         <Route path="/pivot" element={<PivotDemo />} />
         <Route path="/progress" element={<ProgressDemo />} />

--- a/src/docs/components/Layout.tsx
+++ b/src/docs/components/Layout.tsx
@@ -50,6 +50,7 @@ export default function Layout({ children }) {
             <ListItem primary="Label" onClick={() => navigate('/label')} />
             <ListItem primary="List" onClick={() => navigate('/list')} />
             <ListItem primary="Menu" onClick={() => navigate('/menu')} />
+            <ListItem primary="Nav" onClick={() => navigate('/nav')} />
             <ListItem primary="Offcanvas" onClick={() => navigate('/offcanvas')} />
             <ListItem primary="Pivot" onClick={() => navigate('/pivot')} />
             <ListItem primary="Progress" onClick={() => navigate('/progress')} />

--- a/src/docs/components/layout.scss
+++ b/src/docs/components/layout.scss
@@ -126,6 +126,8 @@
 }
 
 .docs-sidebar {
+  overflow: auto;
+
   @media (min-width: 800px) {
     grid-area: sidebar;
     position: sticky;

--- a/src/docs/pages/Components/NavDemo.tsx
+++ b/src/docs/pages/Components/NavDemo.tsx
@@ -1,0 +1,18 @@
+import DemoBox from "@docs/components/DemoBox";
+
+import { Nav, NavItem } from "@components";
+
+export default function NavDemo() {
+  return (
+    <>
+      <h2>Nav</h2>
+      <DemoBox>
+        <Nav>
+          <NavItem>Tab 1</NavItem>
+          <NavItem>Tab 2</NavItem>
+          <NavItem>Tab 3</NavItem>
+        </Nav>
+      </DemoBox>
+    </>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,12 @@ export type { MenuItemsProps } from '@components/MenuItems';
 export { default as MenuTrigger } from '@components/MenuTrigger';
 export type { MenuTriggerProps } from '@components/MenuTrigger';
 
+export { default as Nav } from '@components/Nav';
+export type { NavProps } from '@components/Nav';
+
+export { default as NavItem } from '@components/NavItem';
+export type { NavItemProps } from '@components/NavItem';
+
 export { default as Offcanvas } from '@components/Offcanvas';
 export type { OffcanvasProps } from '@components/Offcanvas';
 


### PR DESCRIPTION
Mellow UI 0.10 is a feature update with the new Nav component and various other changes.

## Changes
- [x] 45153b7 **Pivot**: removes the `variant` prop from the `Pivot` components.
- [x] 5083cd2 **Nav**: adds the `Nav` component, this component is visually the same as the Pivot but does not include tab support.
- [x] 7bde4b8 Removes `string` as a valid type of the `as` prop on all components that accept `as` as a prop.

## Fixes
- [x] 56ca7bb Fixes a misalignment in the SelectControl component.
- [x] 5a8289e Fixes a bug where the navigation of the documentation couldn't be scrolled.