### PR TITLE
Mellow UI 0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vite-plugin-dts": "1.2.0"
       },
       "peerDependencies": {
-        "@sippy-platform/mellow-css": "^0.9.0",
+        "@sippy-platform/mellow-css": "^0.10.0",
         "@sippy-platform/valkyrie": ">=0.15.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@sippy-platform/mellow-css": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.9.0.tgz",
-      "integrity": "sha512-e+i6rFH8EpkZOKrd5mleR/Ng61zLh/ZrZ2ptu9wuW3dxfnMMdSVzNxQcGCq6y0g2FZimn5YmyS8GcgwvpUAgIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.10.0.tgz",
+      "integrity": "sha512-iD+x7Of/oVrdC8f5ekyEDq/TkAjHwOTNn1yQ4ZfW6kpw3xJ8VIPwBz6fVrLusxUHp1UpgO29R4MjYJRDTTuqJQ==",
       "peer": true,
       "peerDependencies": {
         "@sippy-platform/valkyrie": ">=0.15.0"
@@ -1231,19 +1231,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2107,9 +2094,8 @@
     },
     "node_modules/vite": {
       "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
-      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
@@ -2722,9 +2708,9 @@
       }
     },
     "@sippy-platform/mellow-css": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.9.0.tgz",
-      "integrity": "sha512-e+i6rFH8EpkZOKrd5mleR/Ng61zLh/ZrZ2ptu9wuW3dxfnMMdSVzNxQcGCq6y0g2FZimn5YmyS8GcgwvpUAgIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.10.0.tgz",
+      "integrity": "sha512-iD+x7Of/oVrdC8f5ekyEDq/TkAjHwOTNn1yQ4ZfW6kpw3xJ8VIPwBz6fVrLusxUHp1UpgO29R4MjYJRDTTuqJQ==",
       "peer": true,
       "requires": {}
     },
@@ -3051,12 +3037,6 @@
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       }
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3544,8 +3524,6 @@
     },
     "vite": {
       "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
-      "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vite-plugin-dts": "1.2.0"
   },
   "peerDependencies": {
-    "@sippy-platform/mellow-css": "^0.9.0",
+    "@sippy-platform/mellow-css": "^0.10.0",
     "@sippy-platform/valkyrie": ">=0.15.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -1,8 +1,9 @@
-import clsx from 'clsx';
-import { InputHTMLAttributes } from 'react';
-import { InputLabel } from '..';
+import clsx from "clsx";
+import { InputHTMLAttributes } from "react";
+import { InputLabel } from "..";
 
-export interface InputControlProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputControlProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * ID of the input
    */
@@ -54,23 +55,26 @@ export const InputControl = ({
   const uniqueName = name ?? id;
 
   return (
-    <div className="form-floating">
-      <input
-        name={uniqueName}
-        id={id}
-        type={type}
-        value={value}
-        className={clsx(
-          'input',
-          className
-        )}
-        placeholder={placeholder}
-        aria-describedby={helper ? `${uniqueName}-help` : undefined}
-        {...props}
-      />
-      <InputLabel id={uniqueName}>{label}</InputLabel>
-      {helper && <div id={`${uniqueName}-help`} className="input-text">{helper}</div>}
-    </div>
+    <>
+      <div className="form-floating">
+        <input
+          name={uniqueName}
+          id={id}
+          type={type}
+          value={value}
+          className={clsx("input", className)}
+          placeholder={placeholder}
+          aria-describedby={helper ? `${uniqueName}-help` : undefined}
+          {...props}
+        />
+        <InputLabel id={uniqueName}>{label}</InputLabel>
+      </div>
+      {helper && (
+        <div id={`${uniqueName}-help`} className="input-text">
+          {helper}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -7,7 +7,7 @@ export interface InputControlProps
   /**
    * ID of the input
    */
-  id?: string;
+  id: string;
   /**
    * Name of the input
    */
@@ -28,6 +28,10 @@ export interface InputControlProps
    * Placeholder of the input
    */
   placeholder?: string;
+  /**
+   * The callback for changing values
+   */
+  onChange: (value: any | null) => void;
   /**
    * Type of the input
    */
@@ -50,6 +54,7 @@ export const InputControl = ({
   type,
   placeholder,
   helper,
+  onChange,
   ...props
 }: InputControlProps) => {
   const uniqueName = name ?? id;
@@ -64,6 +69,7 @@ export const InputControl = ({
           value={value}
           className={clsx("input", className)}
           placeholder={placeholder}
+          onChange={(event) => onChange({ value: event?.target.value, id })}
           aria-describedby={helper ? `${uniqueName}-help` : undefined}
           {...props}
         />

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -2,8 +2,7 @@ import clsx from "clsx";
 import { InputHTMLAttributes } from "react";
 import { InputLabel } from "..";
 
-export interface InputControlProps
-  extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputControlProps {
   /**
    * ID of the input
    */
@@ -31,7 +30,7 @@ export interface InputControlProps
   /**
    * The callback for changing values
    */
-  onChange: (value: any | null) => void;
+  onChange: (form: { id: string, value: any | null }) => void;
   /**
    * Type of the input
    */

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -91,7 +91,6 @@ export function ListItem<T extends ElementType>({
           [`${color}`]: color,
           'active': active,
           'list-item-colored': fullColor,
-          'list-item-action': !!href || !!onClick || !!startAction || !!endAction,
           'disabled': disabled
         },
         className

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -22,7 +22,7 @@ export interface SelectProps {
   /**
    * Value of the select
    */
-  value?: string | number;
+  value?: any;
   /**
    * The array of options
    */
@@ -30,7 +30,7 @@ export interface SelectProps {
   /**
    * The callback for changing values
    */
-  onChange: (value: string | number | null) => void;
+  onChange: (value: any | null) => void;
   /**
    * The callback for getting the option label
    */
@@ -38,7 +38,7 @@ export interface SelectProps {
   /**
    * The callback for getting the option label
    */
-  getValue?: (value: any) => string;
+  getValue?: (value: any) => any;
   /**
    * Whether the radio group is disabled
    */

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -12,7 +12,7 @@ export interface SelectControlProps {
   /**
    * ID of the input
    */
-  id?: string;
+  id: string;
   /**
    * The name attached of the select
    */
@@ -97,7 +97,7 @@ export const SelectControl = ({
       <div className="form-floating">
         <Listbox
           value={value}
-          onChange={onChange}
+          onChange={(value) => onChange({ value, id })}
           disabled={disabled}
           name={uniqueName}
         >

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -87,7 +87,10 @@ export const SelectControl = ({
   ...props
 }: SelectControlProps) => {
   const uniqueName = name ?? id;
-  const currentValue = useMemo(() => options.find((option) => getValue(option) === value), [options, value]);
+  const currentValue = useMemo(
+    () => options.find((option) => getValue(option) === value),
+    [options, value]
+  );
 
   return (
     <>

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -32,7 +32,7 @@ export interface SelectControlProps {
   /**
    * Value of the select
    */
-  value?: string | number;
+  value?: any;
   /**
    * The array of options
    */
@@ -40,7 +40,7 @@ export interface SelectControlProps {
   /**
    * The callback for changing values
    */
-  onChange: (value: string | number | null) => void;
+  onChange: (value: any | null) => void;
   /**
    * The callback for getting the option label
    */
@@ -48,7 +48,7 @@ export interface SelectControlProps {
   /**
    * The callback for getting the option label
    */
-  getValue?: (value: any) => string;
+  getValue?: (value: any) => any;
   /**
    * Whether the radio group is disabled
    */

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -1,12 +1,12 @@
-import React, { ReactNode, Fragment, useMemo } from 'react';
+import React, { ReactNode, Fragment, useMemo } from "react";
 
-import { InputLabel } from '..';
+import { InputLabel } from "..";
 
-import { Listbox, Transition } from '@headlessui/react';
+import { Listbox, Transition } from "@headlessui/react";
 
-import clsx from 'clsx';
-import ValkyrieIcon, { viAngleDown } from '@sippy-platform/valkyrie';
-import SelectItem from '../SelectItem';
+import clsx from "clsx";
+import ValkyrieIcon, { viAngleDown } from "@sippy-platform/valkyrie";
+import SelectItem from "../SelectItem";
 
 export interface SelectControlProps {
   /**
@@ -87,38 +87,63 @@ export const SelectControl = ({
   ...props
 }: SelectControlProps) => {
   const uniqueName = name ?? id;
-  const currentValue = useMemo(() => {
-    return options.find((option) => getValue(option) === value);
-  }, [options, value]);
+  const currentValue = useMemo(() => options.find((option) => getValue(option) === value), [options, value]);
 
   return (
-    <div className="form-floating">
-      <Listbox value={value} onChange={onChange} disabled={disabled} name={uniqueName}>
-        <Listbox.Button className={clsx('input-select', className)} {...props}>
-          <span className="text-truncate pt-4 pb-1">{currentValue ? getLabel(currentValue) : <span className="select-placeholder">{placeholder}</span>}</span>
-          <span className="d-flex align-items-center">
-            <ValkyrieIcon icon={viAngleDown} />
-          </span>
-        </Listbox.Button>
-        <Transition
-          as={Fragment}
-          enter="transition ease-in duration-50"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="transition ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+    <>
+      <div className="form-floating">
+        <Listbox
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          name={uniqueName}
         >
-          <Listbox.Options className="listbox">
-            {options.map((option, key) => (
-              <SelectItem option={option} getValue={getValue} getLabel={getLabel} key={key} />
-            ))}
-          </Listbox.Options>
-        </Transition>
-      </Listbox>
-      <InputLabel id={uniqueName} shrink={!!value}>{label}</InputLabel>
-      {helper && <div id={`${uniqueName}-help`} className="input-text">{helper}</div>}
-    </div>
+          <Listbox.Button
+            className={clsx("input-select", className)}
+            {...props}
+          >
+            <span className="text-truncate pt-4 pb-1">
+              {currentValue ? (
+                getLabel(currentValue)
+              ) : (
+                <span className="select-placeholder">{placeholder}</span>
+              )}
+            </span>
+            <span className="d-flex align-items-center">
+              <ValkyrieIcon icon={viAngleDown} />
+            </span>
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-in duration-50"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options className="listbox">
+              {options.map((option, key) => (
+                <SelectItem
+                  option={option}
+                  getValue={getValue}
+                  getLabel={getLabel}
+                  key={key}
+                />
+              ))}
+            </Listbox.Options>
+          </Transition>
+        </Listbox>
+        <InputLabel id={uniqueName} shrink={!!value}>
+          {label}
+        </InputLabel>
+      </div>
+      {helper && (
+        <div id={`${uniqueName}-help`} className="input-text">
+          {helper}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -40,7 +40,7 @@ export interface SelectControlProps {
   /**
    * The callback for changing values
    */
-  onChange: (value: any | null) => void;
+  onChange: (form: { id: string, value: any | null }) => void;
   /**
    * The callback for getting the option label
    */

--- a/src/docs/components/layout.scss
+++ b/src/docs/components/layout.scss
@@ -49,7 +49,7 @@
 
 .docs-navigation {
   .list {
-    .list-item.list-item-action {
+    .list-item {
       font-size: 87.5%;
       border-radius: 0;
       color: var(--grey-800) !important;

--- a/src/docs/pages/Forms/FormControlDemo.tsx
+++ b/src/docs/pages/Forms/FormControlDemo.tsx
@@ -28,7 +28,7 @@ export default function FormControlDemo() {
           label="Select planet"
           placeholder="Select planet"
           value={value}
-          onChange={(value: number) => setValue(value)}
+          onChange={(formInput: { id: string, value: any | null }) => setValue(formInput.value)}
           options={[
             { value: 1, label: 'Mercury' },
             { value: 2, label: 'Venus' },


### PR DESCRIPTION
Mellow UI 0.11.0 is a major feature update introducing new form behavior.

## Breaking change
The `InputControl` and `SelectControl` now return an object for their `onChange` callback that includes the `id` of the control and the `value` that was selected. This change brings both of these controls in line with eachother instead of returning an `ChangeEvent` and `T` respectively.

`InputControl` and `SelectControl` both require the `id` prop to be set.

## Changes
- [x] 741e8dc Updates the `InputControl` and `SelectControl` to return the same type with their `onChange` function and to require the `id` prop.
- [x] c825057 Removes the `list-item-action` class for the `ListItem` component.
- [x] 6ff24c0 47abbc8 Allows any value on `Select` and `SelectControl`.

## Fixes
- [x] d8604cc Fixes a bug where the `listbox` in a `SelectControl` would appear under the helper text.