### PR TITLE
Mellow UI 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/InputControl/InputControl.tsx
+++ b/src/components/InputControl/InputControl.tsx
@@ -36,6 +36,10 @@ export interface InputControlProps {
    */
   type?: string;
   /**
+   * If the input is required or not
+   */
+  required?: boolean;
+  /**
    * Custom classes for the label
    */
   className?: string;
@@ -54,6 +58,7 @@ export const InputControl = ({
   placeholder,
   helper,
   onChange,
+  required,
   ...props
 }: InputControlProps) => {
   const uniqueName = name ?? id;
@@ -68,6 +73,7 @@ export const InputControl = ({
           value={value}
           className={clsx("input", className)}
           placeholder={placeholder}
+          required={required}
           onChange={(event) => onChange({ value: event?.target.value, id })}
           aria-describedby={helper ? `${uniqueName}-help` : undefined}
           {...props}

--- a/src/components/SelectControl/SelectControl.tsx
+++ b/src/components/SelectControl/SelectControl.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Fragment, useMemo } from "react";
+import { ReactNode, Fragment, useMemo } from "react";
 
 import { InputLabel } from "..";
 


### PR DESCRIPTION
Mellow UI 0.11.1 fixes an issue with the updated `InputControl`.

## Fixes
- 1efeab1 Restores support for the `required` prop on `InputControl`.