### PR TITLE
Mellow UI 0.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/NavItem/NavItem.tsx
+++ b/src/components/NavItem/NavItem.tsx
@@ -12,6 +12,10 @@ export type NavItemProps<T extends ElementType> = {
    */
   active?: boolean;
   /**
+   * Whether the element is disabled
+   */
+  disabled?: boolean;
+  /**
    * Custom classes for the label
    */
   className?: string;
@@ -28,6 +32,7 @@ export function NavItem<T extends ElementType>({
   as,
   active,
   className,
+  disabled,
   children,
   ...props
 }: NavItemProps<T>) {
@@ -38,10 +43,12 @@ export function NavItem<T extends ElementType>({
       className={clsx(
         'pivot-link',
         {
-          'active': active
+          'active': active,
+          'disabled': disabled
         },
         className
       )}
+      disabled={disabled}
       {...props}
     >
       {children}


### PR DESCRIPTION
Mellow UI 0.11.3 fixes a missing prop in `NavLink`.

## Fixes
- 86a0bd3 Fixes the missing `disabled` prop in the `NavLink` component.