### PR TITLE
Mellow UI 0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.13.4",
+      "version": "0.14.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vite-plugin-dts": "1.4.1"
       },
       "peerDependencies": {
-        "@sippy-platform/mellow-css": ">=0.11.0",
+        "@sippy-platform/mellow-css": ">=0.14.0",
         "@sippy-platform/valkyrie": ">=0.15.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@sippy-platform/mellow-css": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.13.0.tgz",
-      "integrity": "sha512-Lg/LZqd0ofkNPBNOGhuL1ivoA3DdIJAyqAuFHvSUK5PV8YKuVus5j75qyH4W5YV0+UdJaafyvvnk5gu+/JLROQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.0.tgz",
+      "integrity": "sha512-YH9ofdCdyBLVsx4oWmVERkboedX0h5CdDsDkdQCjDb6sO38dPbNRbisZ9Z9SJk6mwM6Bn2Ad7o7E9ZXDiHClvA==",
       "peer": true,
       "peerDependencies": {
         "@sippy-platform/valkyrie": ">=0.15.0"
@@ -3360,9 +3360,9 @@
       }
     },
     "@sippy-platform/mellow-css": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.13.0.tgz",
-      "integrity": "sha512-Lg/LZqd0ofkNPBNOGhuL1ivoA3DdIJAyqAuFHvSUK5PV8YKuVus5j75qyH4W5YV0+UdJaafyvvnk5gu+/JLROQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.0.tgz",
+      "integrity": "sha512-YH9ofdCdyBLVsx4oWmVERkboedX0h5CdDsDkdQCjDb6sO38dPbNRbisZ9Z9SJk6mwM6Bn2Ad7o7E9ZXDiHClvA==",
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vite-plugin-dts": "1.4.1"
   },
   "peerDependencies": {
-    "@sippy-platform/mellow-css": ">=0.11.0",
+    "@sippy-platform/mellow-css": ">=0.14.0",
     "@sippy-platform/valkyrie": ">=0.15.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -8,6 +8,10 @@ export type ListItemProps<T extends ElementType> = {
    */
   primary: string;
   /**
+   * Show a label around the list
+   */
+  secondary?: string;
+  /**
    * Show the list item as active
    */
   active?: boolean;
@@ -67,6 +71,7 @@ export type ListItemProps<T extends ElementType> = {
 export function ListItem<T extends ElementType>({
   active,
   primary,
+  secondary,
   className,
   href,
   onClick,
@@ -103,6 +108,7 @@ export function ListItem<T extends ElementType>({
       {startAction && <span className="list-item-action-s">{startAction}</span>}
       {startIcon && <span className="list-item-icon-s">{startIcon}</span>}
       {primary && <span className={clsx('list-item-label', { 'text-truncate': truncate })}>{primary}</span>}
+      {secondary && <span className={clsx('list-item-description', { 'text-truncate': truncate })}>{secondary}</span>}
       {endIcon && <span className="list-item-icon-e">{endIcon}</span>}
       {endAction && <span className="list-item-action-e">{endAction}</span>}
     </Component>

--- a/src/docs/pages/Components/ListDemo.tsx
+++ b/src/docs/pages/Components/ListDemo.tsx
@@ -23,6 +23,7 @@ export default function ListDemo() {
             />
             <ListItem
               primary="This is also list item"
+              secondary="This is a list item description"
               endAction={<Radio value="second" />}
             />
             <ListItemDivider


### PR DESCRIPTION
Mellow UI 0.14 is a minor feature update.

## Changes
- 98eefa2 Adds support for the `secondary` prop on the `ListItem` component. Mellow CSS 0.14 is now required.