### PR TITLE
Mellow UI 0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-ui",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@headlessui/react": "1.6.6",
@@ -541,15 +541,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.2.tgz",
-      "integrity": "sha512-MwT/Xi1DperfrBO+SU3f/xKdyR6bMvk59/WN6w7g1rHmDBMegan3Ya6npMo+abJAgQOtp6uExY/elHXcYE/Ofw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.3.tgz",
+      "integrity": "sha512-PHq+Oo8yiXhwi11VQ1Nz36s+aZwgFqjtkd41udWHtSpyMv2slJ74m1cHdpWbs2ovGUCfldayzdpGwnexZLd2bA==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.23.0",
+        "@microsoft/api-extractor-model": "7.23.1",
         "@microsoft/tsdoc": "0.14.1",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.50.1",
+        "@rushstack/node-core-library": "3.50.2",
         "@rushstack/rig-package": "0.3.14",
         "@rushstack/ts-command-line": "4.12.2",
         "colors": "~1.2.1",
@@ -564,14 +564,14 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.0.tgz",
-      "integrity": "sha512-h+2aVyf8IYidPZp+N+yIc/LY/aBwRZ1Vxlsx7rU31807bba5ScJ94bj7OjsPMje0vRYALf+yjZToYT0HdP6omA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.1.tgz",
+      "integrity": "sha512-axlZ33H2LfYX7goAaWpzABWZl3JtX/EUkfVBsI4SuMn3AZYBJsP5MVpMCq7jt0PCefWGwwO+Rv+lCmmJIjFhlQ==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.1",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.50.1"
+        "@rushstack/node-core-library": "3.50.2"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/resolve": {
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.50.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.1.tgz",
-      "integrity": "sha512-9d2xE7E9yQEBS6brTptdP8cslt6iL5+UnkY2lRxQQ4Q/jlXtsrWCCJCxwr56W/eJEe9YT/yHR4mMn5QY64Ps2w==",
+      "version": "3.50.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.2.tgz",
+      "integrity": "sha512-+zpZBcaX5s+wA0avF0Lk3sd5jbGRo5SmsEJpElJbqQd3KGFvc/hcyeNSMqV5+esJ1JuTfnE1QyRt8nvxFNTaQg==",
       "dev": true,
       "dependencies": {
         "@types/node": "12.20.24",
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@sippy-platform/mellow-css": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.0.tgz",
-      "integrity": "sha512-YH9ofdCdyBLVsx4oWmVERkboedX0h5CdDsDkdQCjDb6sO38dPbNRbisZ9Z9SJk6mwM6Bn2Ad7o7E9ZXDiHClvA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.1.tgz",
+      "integrity": "sha512-lphhkkOIAJsmAu2p8JE7d5sjjSH3gYnwWeUkeDtuorxujJKySSoCrqA1B0ZC3wp7fR01aPZKtVoBrrS4qqcnlA==",
       "peer": true,
       "peerDependencies": {
         "@sippy-platform/valkyrie": ">=0.15.0"
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001378",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
-      "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
+      "version": "1.0.30001381",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+      "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
       "dev": true,
       "funding": [
         {
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
-      "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
+      "version": "1.4.225",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+      "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -3151,15 +3151,15 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.2.tgz",
-      "integrity": "sha512-MwT/Xi1DperfrBO+SU3f/xKdyR6bMvk59/WN6w7g1rHmDBMegan3Ya6npMo+abJAgQOtp6uExY/elHXcYE/Ofw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.3.tgz",
+      "integrity": "sha512-PHq+Oo8yiXhwi11VQ1Nz36s+aZwgFqjtkd41udWHtSpyMv2slJ74m1cHdpWbs2ovGUCfldayzdpGwnexZLd2bA==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.23.0",
+        "@microsoft/api-extractor-model": "7.23.1",
         "@microsoft/tsdoc": "0.14.1",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.50.1",
+        "@rushstack/node-core-library": "3.50.2",
         "@rushstack/rig-package": "0.3.14",
         "@rushstack/ts-command-line": "4.12.2",
         "colors": "~1.2.1",
@@ -3191,14 +3191,14 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.0.tgz",
-      "integrity": "sha512-h+2aVyf8IYidPZp+N+yIc/LY/aBwRZ1Vxlsx7rU31807bba5ScJ94bj7OjsPMje0vRYALf+yjZToYT0HdP6omA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.1.tgz",
+      "integrity": "sha512-axlZ33H2LfYX7goAaWpzABWZl3JtX/EUkfVBsI4SuMn3AZYBJsP5MVpMCq7jt0PCefWGwwO+Rv+lCmmJIjFhlQ==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.14.1",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.50.1"
+        "@rushstack/node-core-library": "3.50.2"
       }
     },
     "@microsoft/tsdoc": {
@@ -3258,9 +3258,9 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.50.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.1.tgz",
-      "integrity": "sha512-9d2xE7E9yQEBS6brTptdP8cslt6iL5+UnkY2lRxQQ4Q/jlXtsrWCCJCxwr56W/eJEe9YT/yHR4mMn5QY64Ps2w==",
+      "version": "3.50.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.2.tgz",
+      "integrity": "sha512-+zpZBcaX5s+wA0avF0Lk3sd5jbGRo5SmsEJpElJbqQd3KGFvc/hcyeNSMqV5+esJ1JuTfnE1QyRt8nvxFNTaQg==",
       "dev": true,
       "requires": {
         "@types/node": "12.20.24",
@@ -3360,9 +3360,9 @@
       }
     },
     "@sippy-platform/mellow-css": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.0.tgz",
-      "integrity": "sha512-YH9ofdCdyBLVsx4oWmVERkboedX0h5CdDsDkdQCjDb6sO38dPbNRbisZ9Z9SJk6mwM6Bn2Ad7o7E9ZXDiHClvA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@sippy-platform/mellow-css/-/mellow-css-0.14.1.tgz",
+      "integrity": "sha512-lphhkkOIAJsmAu2p8JE7d5sjjSH3gYnwWeUkeDtuorxujJKySSoCrqA1B0ZC3wp7fR01aPZKtVoBrrS4qqcnlA==",
       "peer": true,
       "requires": {}
     },
@@ -3545,9 +3545,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001378",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
-      "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
+      "version": "1.0.30001381",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+      "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
       "dev": true
     },
     "chalk": {
@@ -3673,9 +3673,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
-      "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
+      "version": "1.4.225",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+      "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==",
       "dev": true
     },
     "esbuild": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "@headlessui/react": "1.6.6",
         "clsx": "1.2.1",
         "react-element-to-jsx-string": "15.0.0",
-        "sass": "1.54.4"
+        "sass": "1.54.5"
       },
       "devDependencies": {
-        "@types/node": "18.7.6",
+        "@types/node": "18.7.9",
         "@types/react": "18.0.17",
         "@types/react-dom": "18.0.6",
         "@vitejs/plugin-react": "2.0.1",
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "version": "18.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+      "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==",
       "dev": true
     },
     "node_modules/@types/prismjs": {
@@ -2375,9 +2375,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.54.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+      "version": "1.54.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.5.tgz",
+      "integrity": "sha512-p7DTOzxkUPa/63FU0R3KApkRHwcVZYC0PLnLm5iyZACyp15qSi32x7zVUhRdABAATmkALqgGrjCJAcWvobmhHw==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -3401,9 +3401,9 @@
       }
     },
     "@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "version": "18.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+      "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==",
       "dev": true
     },
     "@types/prismjs": {
@@ -4429,9 +4429,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.54.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+      "version": "1.54.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.5.tgz",
+      "integrity": "sha512-p7DTOzxkUPa/63FU0R3KApkRHwcVZYC0PLnLm5iyZACyp15qSi32x7zVUhRdABAATmkALqgGrjCJAcWvobmhHw==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "@headlessui/react": "1.6.6",
     "clsx": "1.2.1",
     "react-element-to-jsx-string": "15.0.0",
-    "sass": "1.54.4"
+    "sass": "1.54.5"
   },
   "devDependencies": {
-    "@types/node": "18.7.6",
+    "@types/node": "18.7.9",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
     "@vitejs/plugin-react": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-ui",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "React components for the Mellow Design System.",
   "main": "./dist/mellow-ui.umd.js",
   "module": "./dist/mellow-ui.es.js",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface AlertProps {
   /**
    * The variant of the button.
@@ -10,7 +12,7 @@ export interface AlertProps {
   /**
    * The color of the button, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Custom classes for the dialog
    */

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -3,6 +3,8 @@ import useColor from '@hooks/useColor';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface AvatarProps {
   /**
    * The text for the avatar
@@ -19,7 +21,7 @@ export interface AvatarProps {
   /**
    * The color of the avatar, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent' | true;
+  color?: MellowColor | true;
   /**
    * The avatar size.
    */

--- a/src/components/BottomBar/BottomBar.tsx
+++ b/src/components/BottomBar/BottomBar.tsx
@@ -2,11 +2,13 @@ import { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface BottomBarProps {
   /**
    * The color of the bottom bar
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Custom classes for the bottom nav
    */

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,11 +2,13 @@ import { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface BreadcrumbProps {
   /**
    * The color of the breadcrumb
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Custom classes for the bottom nav
    */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,8 @@ import { ElementType, ButtonHTMLAttributes, ReactNode, useMemo, ComponentPropsWi
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 interface IButtonProps<T> extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * The variant of the button.
@@ -10,7 +12,7 @@ interface IButtonProps<T> extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * The color of the button, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * The button size.
    */

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,11 +2,13 @@ import { Menu } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 
+import { MellowColor } from '@types';
+
 export interface DropdownProps {
   /**
    * The color of the button, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Value of the textarea
    */

--- a/src/components/DropdownItem/DropdownItem.tsx
+++ b/src/components/DropdownItem/DropdownItem.tsx
@@ -2,11 +2,13 @@ import { Menu } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { ElementType, ReactNode, useMemo } from 'react';
 
+import { MellowColor } from '@types';
+
 export interface DropdownItemProps<T> {
   /**
    * The color of the button, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Button disabled state.
    */

--- a/src/components/DropdownItem/DropdownItem.tsx
+++ b/src/components/DropdownItem/DropdownItem.tsx
@@ -18,6 +18,10 @@ export interface DropdownItemProps<T> {
    */
   href?: string;
   /**
+   * Optional click handler.
+   */
+  onClick?: () => void;
+  /**
    * Custom classes for the label
    */
   className?: string;
@@ -41,6 +45,7 @@ export function Dropdown<T>({
   color,
   disabled = false,
   children,
+  onClick,
   ...props
 }: DropdownItemProps<T>) {
   const Component = useMemo(() => (as ? as : (href ? 'a' : 'button')) as ElementType, [as, href]);
@@ -58,6 +63,7 @@ export function Dropdown<T>({
             color,
             className
           )}
+          onClick={onClick}
           href={href}
           disabled={disabled}
           {...props}

--- a/src/components/DropdownItem/DropdownItem.tsx
+++ b/src/components/DropdownItem/DropdownItem.tsx
@@ -10,6 +10,10 @@ export interface DropdownItemProps<T> {
    */
   color?: MellowColor;
   /**
+   * Button active state.
+   */
+  active?: boolean;
+  /**
    * Button disabled state.
    */
   disabled?: boolean;
@@ -43,6 +47,7 @@ export function Dropdown<T>({
   className,
   as,
   color,
+  active,
   disabled = false,
   children,
   onClick,
@@ -52,13 +57,13 @@ export function Dropdown<T>({
 
   return (
     <Menu.Item>
-      {({ active }) => (
+      {({ active: isActive }) => (
         <Component
           type="button"
           className={clsx(
             'dropdown-item',
             {
-              'active': active,
+              'active': isActive || active,
             },
             color,
             className

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface LabelProps {
   /**
    * The variant of the button.
@@ -10,7 +12,7 @@ export interface LabelProps {
   /**
    * The color of the button, only works when the variant is `color` or `hover`
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Label contents.
    */

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface ListProps {
   /**
    * Show a border around the list
@@ -14,7 +16,7 @@ export interface ListProps {
   /**
    * The color of the list
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * The button size.
    */

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -2,6 +2,8 @@ import { ComponentPropsWithoutRef, ElementType, ReactNode, useMemo } from 'react
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export type ListItemProps<T extends ElementType> = {
   /**
    * Show a label around the list
@@ -26,7 +28,7 @@ export type ListItemProps<T extends ElementType> = {
   /**
    * The color of the list item
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Theme the item fully
    */

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 
 import clsx from 'clsx';
 
+import { MellowColor } from '@types';
+
 export interface ProgressProps {
   /**
    * The highest value on the progress bar
@@ -14,7 +16,7 @@ export interface ProgressProps {
   /**
    * Color of the progress bar
    */
-  color?: 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';
+  color?: MellowColor;
   /**
    * Size of the progress bar
    */

--- a/src/hooks/useColor.tsx
+++ b/src/hooks/useColor.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-type MellowColor = 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey';
+import { MellowColor } from '@types';
 
 export default function useColor(string: string): MellowColor {
   const colors: MellowColor[] = ['red', 'orange', 'amber', 'yellow', 'lime', 'green', 'teal', 'cyan', 'blue', 'indigo', 'violet', 'purple', 'pink', 'rose', 'brown', 'grey'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,4 +182,4 @@ export type { ToolbarProps } from '@components/Toolbar';
 
 export { default as useColor } from '@hooks/useColor';
 
-export { MellowColors } from '@types';
+export { MellowColor } from '@types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,3 +181,5 @@ export { default as Toolbar } from '@components/Toolbar';
 export type { ToolbarProps } from '@components/Toolbar';
 
 export { default as useColor } from '@hooks/useColor';
+
+export { MellowColors } from '@types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export type MellowColor = 'red' | 'orange' | 'amber' | 'yellow' | 'lime' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'purple' | 'pink' | 'rose' | 'brown' | 'grey' | 'accent';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,10 @@
     "outDir": "dist",
     "paths": {
       "@": ["./src/index.ts"],
-      "@docs/*": ["./src/docs/*"],
       "@components/*": ["./src/components/*"],
-      "@hooks/*": ["./src/hooks/*"]
+      "@docs/*": ["./src/docs/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@types/*": ["./src/types/*"],
     }
   },
   "include": ["src/index.ts", "src/components", "src/hooks"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,9 +27,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src/index.ts'),
-      '@docs': path.resolve(__dirname, './src/docs'),
       '@components': path.resolve(__dirname, './src/components'),
+      '@docs': path.resolve(__dirname, './src/docs'),
       '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@types': path.resolve(__dirname, './src/types'),
     },
   }
 })


### PR DESCRIPTION
Mellow UI 0.15 is a minor feature update including updates types and an improved Dropdown component.

## Changes
- 614fa17 32eb846 `MellowColor` is now an exported type and is now used internally wherever it is aplicable.
- 97e2905 Support for `onClick` on the `DropdownItem`.
- 481425e Support for `active` on the `DropdownItem